### PR TITLE
Raise error if userData.id is undefined/null

### DIFF
--- a/src/stream-analytics.js
+++ b/src/stream-analytics.js
@@ -13,6 +13,14 @@ StreamAnalytics.prototype.configure = function(cfg) {
 };
 
 StreamAnalytics.prototype.setUser = function(userData) {
+  if (!userData) {
+    throw new TypeError('Empty userData, supply userData object as a first argument');
+  }
+
+  if (!userData.id) {
+    throw new errors.MissingUserId('userData.id was not set');
+  }
+
   this.userData = userData;
 };
 
@@ -31,10 +39,6 @@ StreamAnalytics.prototype._sendEventFactory = function(resourceName, dataSpec) {
 StreamAnalytics.prototype._sendEvent = function(resourceName, eventData) {
   if (this.userData === null) {
     throw new errors.MissingUserId('userData was not set');
-  }
-
-  if (! this.userData.id) {
-    throw new errors.MissingUserId('userData.id was not set');
   }
 
   eventData['user_data'] = this.userData;

--- a/src/stream-analytics.js
+++ b/src/stream-analytics.js
@@ -33,6 +33,10 @@ StreamAnalytics.prototype._sendEvent = function(resourceName, eventData) {
     throw new errors.MissingUserId('userData was not set');
   }
 
+  if (! this.userData.id) {
+    throw new errors.MissingUserId('userData.id was not set');
+  }
+
   eventData['user_data'] = this.userData;
   return this.client.send(resourceName, eventData);
 };

--- a/tests/async.html
+++ b/tests/async.html
@@ -15,7 +15,7 @@ mocha.setup('bdd');
 
 var consFunStr = window.StreamAnalytics.toString();
 var streamAnalytics = new StreamAnalytics({ apiKey: 'key', token: 'token' });
-streamAnalytics.setUser('thierry');
+streamAnalytics.setUser({ id: 1, alias: 'thierry' });
 
 describe('Getstream load async', function() {
     var tag = document.getElementsByTagName('script')[0];
@@ -47,7 +47,7 @@ describe('Getstream load async', function() {
     it('replaces the stub onload', function(done) {
         function testIt() {
             expect(window.StreamAnalytics.toString()).to.not.be(consFunStr);
-            expect(streamAnalytics.userId).to.be('thierry');
+            expect(streamAnalytics.userData.alias).to.be('thierry');
 
             expect(streamAnalytics.client.apiKey).to.be('key');
             expect(streamAnalytics.client.token).to.be('token');

--- a/tests/index.js
+++ b/tests/index.js
@@ -37,10 +37,30 @@ describe('StreamAnalytics', function () {
         'token': 'token'
     });
     expect(analytics.userData).to.eql(null);
-    analytics.setUser('user_data');
-    expect(analytics.userData).to.eql('user_data');
+    analytics.setUser({ id: 1, alias: 'user' });
+    expect(analytics.userData).to.eql({ id: 1, alias: 'user' });
     done();
   });
+
+  it('should break on userData without id', function() {
+        var analytics = new StreamAnalytics({
+            'apiKey': 'key',
+            'token': 'token'
+        });
+
+        function shouldThrow() {
+            analytics.setUser({ id: null });
+        }
+
+        function shouldThrow2() {
+            analytics.setUser();
+        }
+
+        expect(shouldThrow).to.throwError();
+        expect(shouldThrow2).to.throwException(function(e) {
+            expect(e).to.be.a(TypeError);
+        });
+    });
 
   it('should break on impressions without content_list', function () {
     var analytics = new StreamAnalytics({
@@ -303,7 +323,7 @@ describe('analytics client integration', function () {
 
   it('should store track impressions', function () {
     var analytics = new StreamAnalytics({'apiKey': apiKey, 'token': token});
-    analytics.setUser('tommaso');
+    analytics.setUser({ id: 1, alias: 'tommaso' });
     analytics.trackImpression({
         'content_list': ['1', 2, '3'],
         'features': [
@@ -315,7 +335,7 @@ describe('analytics client integration', function () {
 
   it('should store track engagements', function () {
     var analytics = new StreamAnalytics({'apiKey': apiKey, 'token': token});
-    analytics.setUser('tommaso');
+    analytics.setUser({ id: 1, alias: 'tommaso' });
     analytics.trackEngagement({
         'content': '1',
         'label': 'click',


### PR DESCRIPTION
If you set the userData to an object with id = null we should raise a validation error. Because the analytics API will not store impressions/engagement tracked for this user correctly.